### PR TITLE
chore(.github): schedule govulncheck run weekly on Sunday 12:00 AM (UTC)

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,5 +1,7 @@
 name: Go Vulnerability Check
 on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at 12:00 AM (UTC)
   push:
     branches:
     - master


### PR DESCRIPTION
### Description

Schedule [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to run weekly via GitHub workflow cron every Sunday at 12:00 AM (UTC).